### PR TITLE
Insert GTM tag in place of others

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,33 +4,13 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-78530187-23"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'UA-78530187-23');
-    </script>
-    <!-- Google tag GA4 (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VF1WCN3Y71"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-VF1WCN3Y71');
-    </script>
-    <!-- VIZLAB Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-FWMWJQHLM6"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-FWMWJQHLM6');
-    </script>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KKHGS9X');</script>
+    <!-- End Google Tag Manager -->
     <%= process.env.VUE_APP_TIER !== '' ? '<meta name="robots" content="noindex,nofollow">' : '' %><!-- an empty string in this case means the 'prod' version of the application   -->
       <!-- Primary Meta Tags -->
       <title>
@@ -87,6 +67,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KKHGS9X"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript>
       <strong>We're sorry but this application doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>


### PR DESCRIPTION
This PR replaces the UA and GA4 tags with the GTM tag.

The GTM container has been configured to point to the existing GA4 account.

Tags on [existing page](https://labs.waterdata.usgs.gov/visualizations/pools-and-fluxes/index.html#/): 

![image](https://github.com/DOI-USGS/pools-and-fluxes/assets/54007288/ac02b002-5257-462d-978e-b2678e09860f)


Tags on updated page (previewed from local host):

![image](https://github.com/DOI-USGS/pools-and-fluxes/assets/54007288/5cab2877-d2d2-48fd-aa64-3233c627a9ec)



Before making a pull request
----------------------------
First . . .
- [X] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [X] Chrome
- [ ] Safari
- [X] Edge
- [X] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)